### PR TITLE
Use compileOnly instead of compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.discordsrv:discordsrv:1.18.1'
+    compileOnly 'com.discordsrv:discordsrv:1.18.1'
 }
 ```


### PR DESCRIPTION
`compile` adds the entire jar file (fat-jar/`compile` scope in Maven) whereas
`compileOnly` is the equivalent to Maven's `provided`.